### PR TITLE
feat: generate introspection result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ typings/
 # Serverless directories
 .serverless
 
-# Flow types
+# Flow types and introspection result
 types.js.flow
+introspection-result.js

--- a/codegen.yml
+++ b/codegen.yml
@@ -4,3 +4,6 @@ generates:
   types.js.flow:
     plugins:
       - "flow"
+  ./introspection-result.js:
+    plugins:
+      - "fragment-matcher"

--- a/package-lock.json
+++ b/package-lock.json
@@ -576,6 +576,29 @@
         }
       }
     },
+    "@graphql-codegen/fragment-matcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/fragment-matcher/-/fragment-matcher-1.2.1.tgz",
+      "integrity": "sha512-xDLS/iSinrcnVDCJ+VGyHbrIW1+VKWig+f2ALe7jjW61SYBlQ/MTph1KX5/S5LiNz3j+xm889FerJuhUXshNRA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.2.1"
+      },
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.2.1.tgz",
+          "integrity": "sha512-iymI6pZ9c46vAK8sDSQ+NP/fPMi0/46xtSsXK/QmRkVkRSxU2RtmXsFY2q04WT91C08/wRSTQLta8jkktg8yKg==",
+          "dev": true,
+          "requires": {
+            "change-case": "3.1.0",
+            "common-tags": "1.8.0",
+            "import-from": "3.0.0",
+            "tslib": "1.9.3"
+          }
+        }
+      }
+    },
     "@graphql-codegen/plugin-helpers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "__schema__",
     "index.js.flow",
-    "types.js.flow"
+    "types.js.flow",
+    "introspection-result.js"
   ],
   "publishConfig": {
     "access": "public"
@@ -33,6 +34,7 @@
     "@commitlint/config-conventional": "^7.5.0",
     "@graphql-codegen/cli": "^1.1.3",
     "@graphql-codegen/flow": "1.1.3",
+    "@graphql-codegen/fragment-matcher": "^1.2.1",
     "conventional-github-releaser": "^3.1.2",
     "graphql": "^0.13.0",
     "graphql-schema-linter": "^0.1.6",


### PR DESCRIPTION
[Fragments on unions and interfaces](https://www.apollographql.com/docs/react/advanced/fragments/#fragments-on-unions-and-interfaces)
> By default, Apollo Client's cache will use a heuristic fragment matcher, which assumes that a fragment matched if the result included all the fields in its selection set, and didn't match when any field was missing. This works in most cases, but it also means that Apollo Client cannot check the server response for you, and it cannot tell you when you're manually writing an invalid data into the store using update, updateQuery, writeQuery, etc.

> To support result validation and accurate fragment matching on unions and interfaces, a special fragment matcher called the IntrospectionFragmentMatcher can be used. If there are any changes related to union or interface types in your schema, you will have to update the fragment matcher accordingly.

In short, we cannot update our cache in Apollo without introspection. Everything falls with an error and the update does not occur. It all happens because we use fragments, so we need this introspection