### PR TITLE
fix: move `employeeRoles` to employee, move `healthcareServices` to LE

### DIFF
--- a/__schema__/employeeRoles.graphql
+++ b/__schema__/employeeRoles.graphql
@@ -1,16 +1,7 @@
-# import Employee from "employees.graphql"
 # import HealthcareService from "healthcareServices.graphql"
 
 """
-Fields to filter employee role in the system.
-"""
-input EmployeeRoleFilter {
-  "Primary key identifier from the database."
-  databaseId: UUID
-}
-
-"""
-Methods to use when ordering `Employee role`.
+Methods to use when ordering `EmployeeRole`.
 """
 enum EmployeeRoleOrderBy {
   "Sort employee role by inserted_at in ascending order."
@@ -20,7 +11,7 @@ enum EmployeeRoleOrderBy {
 }
 
 """
-A connection to a list of `Employee role` items.
+A connection to a list of `EmployeeRole` items.
 """
 type EmployeeRoleConnection {
   "Information to aid in pagination."
@@ -32,7 +23,7 @@ type EmployeeRoleConnection {
 }
 
 """
-An edge in a connection of `Employee role`.
+An edge in a connection of `EmployeeRole`.
 """
 type EmployeeRoleEdge {
   "The item at the end of the edge."
@@ -51,11 +42,9 @@ type EmployeeRole implements Node {
   id: ID!
   "Information about healthcare service"
   healthcareService: HealthcareService!
-  "Information about employee"
-  employee: Employee!
   "Relation is started at"
   startDate: DateTime!
-  "Realtion is ended at"
+  "Relation is ended at"
   endDate: DateTime
   "Status of employee role"
   status: EmployeeRoleStatus!

--- a/__schema__/employees.graphql
+++ b/__schema__/employees.graphql
@@ -1,3 +1,5 @@
+# import EmployeeRoleFilter, EmployeeRoleOrderBy, EmployeeRoleConnection from "employeeRoles.graphql"
+
 """
 Fields to filter employee in the system.
 """
@@ -110,6 +112,19 @@ type Employee implements Node {
   division: Division
   "Legal entity in which employee works."
   legalEntity: LegalEntity!
+  "Reads and enables pagination through a set of `Employee roles`."
+  roles(
+    "The method to use when ordering collection items."
+    orderBy: EmployeeRoleOrderBy
+    "Read all values in the set after (below) this cursor."
+    after: String
+    "Read all values in the set before (above) this cursor."
+    before: String
+    "Only read the first _n_ values of the set."
+    first: Int
+    "Only read the last _n_ values of the set."
+    last: Int
+  ): EmployeeRoleConnection!
 }
 
 """

--- a/__schema__/healthcareServices.graphql
+++ b/__schema__/healthcareServices.graphql
@@ -2,14 +2,6 @@
 # import Division from "divisions.graphql"
 
 """
-Fields to filter Healthcare service in the system.
-"""
-input HealthcareServiceFilter {
-  "Primary key identifier from the database."
-  databaseId: UUID
-}
-
-"""
 Methods to use when ordering `Healthcare service`.
 """
 enum HealthcareServiceOrderBy {

--- a/__schema__/index.graphql
+++ b/__schema__/index.graphql
@@ -32,8 +32,6 @@
 # import * from "employeeRequests.graphql"
 # import * from "globalParameters.graphql"
 # import * from "declarationsTerminationJobs.graphql"
-# import * from "healthcareServices.graphql"
-# import * from "employeeRoles.graphql"
 
 """
 The query root of e-Health GraphQL interface.
@@ -503,38 +501,6 @@ type Query {
 
   "Reads global parameters."
   globalParameters: GlobalParameters
-
-  "Reads and enables pagination through a set of `Healthcare service`."
-  healthcareServices(
-    "A condition to be used in determining which values should be returned by the collection."
-    filter: HealthcareServiceFilter
-    "The method to use when ordering collection items."
-    orderBy: HealthcareServiceOrderBy
-    "Read all values in the set after (below) this cursor."
-    after: String
-    "Read all values in the set before (above) this cursor."
-    before: String
-    "Only read the first _n_ values of the set."
-    first: Int
-    "Only read the last _n_ values of the set."
-    last: Int
-  ): HealthcareServiceConnection!
-
-  "Reads and enables pagination through a set of `Employee roles`."
-  employeeRoles(
-    "A condition to be used in determining which values should be returned by the collection."
-    filter: EmployeeRoleFilter
-    "The method to use when ordering collection items."
-    orderBy: EmployeeRoleOrderBy
-    "Read all values in the set after (below) this cursor."
-    after: String
-    "Read all values in the set before (above) this cursor."
-    before: String
-    "Only read the first _n_ values of the set."
-    first: Int
-    "Only read the last _n_ values of the set."
-    last: Int
-  ): EmployeeRoleConnection!
 }
 
 """

--- a/__schema__/legalEntities.graphql
+++ b/__schema__/legalEntities.graphql
@@ -4,6 +4,7 @@
 # import Employee from "employees.graphql"
 # import LegalEntityLicenseFilter, LegalEntityLicenseOrderBy, LegalEntityLicenseConnection from "legalEntityLicenses.graphql"
 # import RelatedLegalEntityFilter, RelatedLegalEntityOrderBy, RelatedLegalEntityConnection from "relatedLegalEntities.graphql"
+# import HealthcareServiceFilter, HealthcareServiceOrderBy, HealthcareServiceConnection from "healthcareServices.graphql"
 
 """
 A condition to be used against `LegalEntity` object types. All fields are tested for equality and combined with a logical ‘and.’
@@ -329,6 +330,19 @@ type LegalEntity implements Node {
     "Only read the last _n_ values of the set."
     last: Int
   ): RelatedLegalEntityConnection!
+  "Reads and enables pagination through a set of `Healthcare service`."
+  healthcareServices(
+    "The method to use when ordering collection items."
+    orderBy: HealthcareServiceOrderBy
+    "Read all values in the set after (below) this cursor."
+    after: String
+    "Read all values in the set before (above) this cursor."
+    before: String
+    "Only read the first _n_ values of the set."
+    first: Int
+    "Only read the last _n_ values of the set."
+    last: Int
+  ): HealthcareServiceConnection!
 }
 
 """


### PR DESCRIPTION
I'm not sure that we need filter by id, сonsidering that we don't use these connections outside Employee or LE queries. I think we can use `id` from root query inside resolver